### PR TITLE
feat(vault-agent): use caching to authenticate against vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cat << 'EOF' > /usr/local/bin/vault-snapshot
 #  - /etc/vault.d/vault_snapshot_agent.hcl
 #  - /etc/systemd/system/vault-agent.service
 
-VAULT_ADDR="http://127.0.0.1:8222" \
+VAULT_ADDR="VAULT_ADDR=unix:///etc/vault.d/agent.sock" \
 /usr/local/bin/vault operator raft snapshot save "/opt/vault/snapshots/vault-raft_$(date +%F-%H%M).snapshot"
 EOF
 ```

--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ auto_auth {
     }
   }
 
-  sink {
-    # write Vault token to file
-    # https://www.vaultproject.io/docs/agent/autoauth/sinks/file
-    type = "file"
+  cache {
+    # Authenticate all requests automatically with the auto_auth token
+    # https://developer.hashicorp.com/vault/docs/agent/caching
+    use_auto_auth_token = true
+  }
 
-    config = {
-      # best practice to write the file to a ramdisk (0640)
-      # have a look at wrapped token for advanced configuration
-      path = "/run/vault-snap-agent/token"
-    }
+  listener "tcp" {
+    # Expose Vault-API seperately
+    # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
+    address = "127.0.0.1:8222"
   }
 }
 EOF
@@ -126,7 +126,7 @@ cat << 'EOF' > /usr/local/bin/vault-snapshot
 #  - /etc/vault.d/vault_snapshot_agent.hcl
 #  - /etc/systemd/system/vault-agent.service
 
-VAULT_TOKEN=$(cat /run/vault-snap-agent/token) VAULT_ADDR="https://$HOSTNAME:8200" \
+VAULT_ADDR="http://127.0.0.1:8222" \
 /usr/local/bin/vault operator raft snapshot save "/opt/vault/snapshots/vault-raft_$(date +%F-%H%M).snapshot"
 EOF
 ```

--- a/ansible/Readme.md
+++ b/ansible/Readme.md
@@ -33,5 +33,4 @@ $ systemctl list-timers
 The Ansible role comes with the following limitations:
 
 * Does not configure a cron job, only a systemd timer/service pair
-* Exposes a Vault token on the snapshot host (with limited privileges though)
 * Does not automatically [install the Vault binary](https://learn.hashicorp.com/tutorials/vault/getting-started-install)

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -6,6 +6,10 @@ vault_snapshot_config_dir: '/etc/vault.d'
 vault_snapshot_pid_file_name: 'vault-raft-backup-agent.pid'
 # Location of pid file
 vault_snapshot_pid_dir: '{{ vault_snapshot_config_dir }}'
+# Systemd runtime directory
+vault_snapshot_run_dir: 'vault-raft-backup-agent'
+# Vault agent listener unix socket
+vault_snapshot_listener_socket: '{{ vault_snapshot_config_dir }}/agent.sock'
 
 # Vault API address
 vault_address: '127.0.0.1'
@@ -77,11 +81,3 @@ vault_snapshot_retention_find_mode: 'mtime'
 vault_snapshot_retention_time: '+7'
 # Action to take on expired files
 vault_snapshot_retention_find_action: 'rm'
-
-# Location of the Vault listener socket:
-# https://developer.hashicorp.com/vault/docs/agent#example-configuration
-vault_snapshot_listener: '/run/vault-snap-agent/socket'
-vault_snapshot_listener_protocol: 'unix'
-# can also be a tcp listner
-#vault_snapshot_listener_protocol: 'http'
-#vault_snapshot_listener: '127.0.0.1:8222'

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -84,3 +84,11 @@ vault_snapshot_retention_find_mode: 'mtime'
 vault_snapshot_retention_time: '+7'
 # Action to take on expired files
 vault_snapshot_retention_find_action: 'rm'
+
+# Location of the Vault listener socket:
+# https://developer.hashicorp.com/vault/docs/agent#example-configuration
+vault_snapshot_listener: '/run/vault-snap-agent/socket'
+vault_snapshot_listener_protocol: 'unix'
+# can also be a tcp listner
+#vault_snapshot_listener_protocol: 'http'
+#vault_snapshot_listener: '127.0.0.1:8222'

--- a/ansible/roles/vault-raft-backup-agent/defaults/main.yml
+++ b/ansible/roles/vault-raft-backup-agent/defaults/main.yml
@@ -65,13 +65,6 @@ vault_snapshot_approle_secretid_file: '{{ vault_snapshot_config_dir }}/snap-secr
 # https://www.vaultproject.io/docs/agent/autoauth/methods/approle#remove_secret_id_file_after_reading
 remove_secret_id_file_after_reading: yes
 
-# Location of the Vault token, ideally a ramdisk, see also:
-# https://www.vaultproject.io/docs/agent/autoauth/sinks/file
-vault_snapshot_token_location: '/run/vault-snap-agent/token'
-# Set to 0000 to prevent Vault from modifying the file mode
-# The file is currently written with 0640 permissions as default
-vault_snapshot_token_mode: '0000'
-
 # Snapshot output directory
 vault_snapshot_dir: '/opt/vault/snapshots'
 # Snapshot file name format

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-raft-backup-agent.service.j2
@@ -5,13 +5,13 @@ After=network-online.target
 
 [Service]
 Restart=on-failure
-ExecStart={{ vault_bin_path }}/vault agent -config={{ vault_snapshot_agent_config_file }}
+ExecStart={{ vault_bin_path }}/vault proxy -config={{ vault_snapshot_agent_config_file }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 User={{ vault_user }}
 Group={{ vault_group }}
 RuntimeDirectoryMode=0750
-RuntimeDirectory=vault-snap-agent
+RuntimeDirectory={{ vault_snapshot_run_dir }}
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,7 +3,7 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-Environment=VAULT_ADDR=http://127.0.0.1:8222
+Environment=VAULT_ADDR={{ vault_snapshot_listener_protocol }}://{{ vault_snapshot_listener }}
 ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,8 +3,8 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-Environment=VAULT_ADDR={{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:8200
-ExecStart=/bin/sh -c 'VAULT_TOKEN="$$(cat /run/vault-snap-agent/token)" {{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
+Environment=VAULT_ADDR=http://127.0.0.1:8222
+ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 
 [Install]

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/systemd/system/vault-snap-agent.service.j2
@@ -3,7 +3,7 @@ Description={{ vault_snapshot_systemd_timer_description }}
 
 [Service]
 Type=oneshot
-Environment=VAULT_ADDR={{ vault_snapshot_listener_protocol }}://{{ vault_snapshot_listener }}
+Environment=VAULT_ADDR=unix://{{ vault_snapshot_listener_socket }}
 ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault operator raft snapshot save "{{ vault_snapshot_dir }}/{{ vault_snapshot_file_name }}"'
 ExecStartPost=/bin/sh -c 'find {{ vault_snapshot_dir }}/* -{{ vault_snapshot_retention_find_mode }} {{ vault_snapshot_retention_time }} -exec {{ vault_snapshot_retention_find_action }} {} \;'
 

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
@@ -16,16 +16,16 @@ vault {
   tls_skip_verify = "{{ vault_tls_skip_verify | ternary('true', 'false') }}"
 }
 
-cache {
+api_proxy {
   # Authenticate all requests automatically with the auto_auth token
-  # https://developer.hashicorp.com/vault/docs/agent/caching
+  # https://developer.hashicorp.com/vault/docs/agent-and-proxy/proxy/apiproxy
   use_auto_auth_token = true
 }
 
-listener "tcp" {
+listener "unix" {
   # Expose Vault-API seperately
   # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
-  address = "{{ vault_snapshot_listener }}"
+  address = "{{ vault_snapshot_listener_socket }}"
   tls_disable = true
 }
 

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
@@ -25,7 +25,8 @@ cache {
 listener "tcp" {
   # Expose Vault-API seperately
   # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
-  address = "127.0.0.1:8222"
+  address = "{{ vault_snapshot_listener }}"
+  tls_disable = true
 }
 
 auto_auth {

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
@@ -29,16 +29,15 @@ auto_auth {
     }
   }
 
-  sink {
-    # write Vault token to file
-    # https://www.vaultproject.io/docs/agent/autoauth/sinks/file
-    type = "file"
+  cache {
+    # Authenticate all requests automatically with the auto_auth token
+    # https://developer.hashicorp.com/vault/docs/agent/caching
+    use_auto_auth_token = true
+  }
 
-    config = {
-      # best practice to write the file to a ramdisk (0640)
-      # have a look at wrapped token for advanced configuration
-      path = "{{ vault_snapshot_token_location }}"
-      mode = {{ vault_snapshot_token_mode }}
-    }
+  listener "tcp" {
+    # Expose Vault-API seperately
+    # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
+    address = "127.0.0.1:8222"
   }
 }

--- a/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
+++ b/ansible/roles/vault-raft-backup-agent/templates/etc/vault.d/vault_snapshot_agent.hcl.j2
@@ -16,6 +16,18 @@ vault {
   tls_skip_verify = "{{ vault_tls_skip_verify | ternary('true', 'false') }}"
 }
 
+cache {
+  # Authenticate all requests automatically with the auto_auth token
+  # https://developer.hashicorp.com/vault/docs/agent/caching
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+  # Expose Vault-API seperately
+  # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
+  address = "127.0.0.1:8222"
+}
+
 auto_auth {
   method {
     # Authenticate with AppRole
@@ -27,17 +39,5 @@ auto_auth {
       secret_id_file_path = "{{ vault_snapshot_approle_secretid_file }}"
       remove_secret_id_file_after_reading = {{ remove_secret_id_file_after_reading | bool | lower }}
     }
-  }
-
-  cache {
-    # Authenticate all requests automatically with the auto_auth token
-    # https://developer.hashicorp.com/vault/docs/agent/caching
-    use_auto_auth_token = true
-  }
-
-  listener "tcp" {
-    # Expose Vault-API seperately
-    # https://developer.hashicorp.com/vault/docs/agent/caching#configuration-listener
-    address = "127.0.0.1:8222"
   }
 }


### PR DESCRIPTION
Uses vault agent's cache feature to authenticate against vault instead of using a sink file.

Not sure if we want it to replace the prior configuration, or add it as an additional option. What do think @in0rdr ?

Related to https://github.com/adfinis/vault-raft-backup-agent/issues/3