### PR TITLE
Remove expired snapshots

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ARG VAULT_VERSION=1.13.2
+ARG VAULT_VERSION=1.16.3
 
 COPY vault-snapshot.sh /
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -15,5 +15,20 @@ After the snapshot is created in a temporary directory, `s3cmd` is used to sync 
 * `S3_URI` - S3 URI to use to upload (s3://xxx)
 * `S3_BUCKET` - S3 bucket to point to
 * `S3_HOST` - S3 endpoint
+* `S3_EXPIRE_DAYS` - Delete files older than this threshold (expired)
 * `AWS_ACCESS_KEY_ID` - Access key to use to access S3
 * `AWS_SECRET_ACCESS_KEY` - Secret access key to use to access S3
+
+## Configuration of file retention (pruning)
+
+With AWS S3, use [lifecycle
+rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html)
+to configure retention and automatic cleanup action (prune) for expired files.
+
+For other S3 compatible storage, ensure to set [Governance
+lock](https://community.exoscale.com/documentation/storage/versioning/#set-up-the-lock-configuration-for-a-bucket)
+to avoid any modification before `$S3_EXPIRE_DAYS`:
+
+```
+mc retention set --default GOVERNANCE "${S3_EXPIRE_DAYS}d" my-s3-remote/my-bucket
+```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -32,3 +32,13 @@ to avoid any modification before `$S3_EXPIRE_DAYS`:
 ```
 mc retention set --default GOVERNANCE "${S3_EXPIRE_DAYS}d" my-s3-remote/my-bucket
 ```
+
+On removal by the `vault-snapshot.sh` script, [`DEL` deletion marker
+(tombstone)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-managing.html#object-lock-managing-delete-markers)
+is set:
+
+```
+mc ls --versions my-snapshots/vault-snapshots-2f848f
+[2024-09-09 09:07:46 CEST]     0B X/1031980658232456253 v2 DEL vault_2024-09-06-1739.snapshot
+[2024-09-06 19:39:49 CEST]  28KiB Standard 1031052557042383613 v1 PUT vault_2024-09-06-1739.snapshot
+```

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -42,3 +42,12 @@ mc ls --versions my-snapshots/vault-snapshots-2f848f
 [2024-09-09 09:07:46 CEST]     0B X/1031980658232456253 v2 DEL vault_2024-09-06-1739.snapshot
 [2024-09-06 19:39:49 CEST]  28KiB Standard 1031052557042383613 v1 PUT vault_2024-09-06-1739.snapshot
 ```
+
+Use [`mc
+undo`](https://min.io/docs/minio/linux/reference/minio-mc/mc-undo.html) to undo
+the `DEL` operation:
+```
+mc undo my-snapshots/vault-snapshots-2f848f/vault_2024-09-06-1739.snapshot
+mc ls --versions my-snapshots/vault-snapshots-2f848f
+[2024-09-06 19:39:49 CEST]  28KiB Standard 1031052557042383613 v1 PUT vault_2024-09-06-1739.snapshot
+```

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -32,6 +32,9 @@ spec:
               value: bucketname
             - name: S3_URI
               value: s3://bucketname
+              # leave empty to retain snapshot files (default)
+            - name: S3_EXPIRE_DAYS
+              value:
             - name: VAULT_ROLE
               value: vault-snapshot
             - name: VAULT_ADDR

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -17,7 +17,7 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
-        olderThan=$(date --date @$((`date +%s` - 86400*$S3_EXPIRE_DAYS)) +%s)
+        olderThan=$(date --date @$(($(date +%s$) - 86400*$S3_EXPIRE_DAYS)) +%s)
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -18,9 +18,9 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
         olderThan=$(date --date "${S3_EXPIRE_DAYS} days ago" +%s)
-        if [ $createDate -lt $olderThan ]; then
+        if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
-            if [ $fileName != "" ]; then
+            if [ "$fileName" != "" ]; then
                 s3cmd del "${S3_URI}/$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
             fi
         fi

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -17,7 +17,7 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
-        olderThan=$(date --date "${S3_EXPIRE_DAYS} days ago" +%s)
+        olderThan=$(date --date @$((`date +%s` - 86400*$S3_EXPIRE_DAYS)) +%s)
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -7,8 +7,22 @@ VAULT_TOKEN=$(vault write -field=token  auth/kubernetes/login role="${VAULT_ROLE
 export VAULT_TOKEN
 
 # create snapshot
-
 vault operator raft snapshot save /vault-snapshots/vault_"$(date +%F-%H%M)".snapshot
 
 # upload to s3
 s3cmd put /vault-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
+
+# remove expired snapshots
+if [ "${S3_EXPIRE_DAYS}" ]; then
+    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
+        createDate=$(echo $line | awk {'print $1" "$2'})
+        createDate=$(date -d"$createDate" +%s)
+        olderThan=$(date --date "${S3_EXPIRE_DAYS} days ago" +%s)
+        if [[ $createDate -lt $olderThan ]]; then
+            fileName=$(echo $line | awk {'print $4'})
+            if [[ $fileName != "" ]]; then
+                s3cmd del "${S3_URI}/$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
+            fi
+        fi
+    done;
+fi

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -15,12 +15,12 @@ s3cmd put /vault-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3
 # remove expired snapshots
 if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
-        createDate=$(echo $line | awk {'print $1" "$2'})
+        createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
         olderThan=$(date --date "${S3_EXPIRE_DAYS} days ago" +%s)
-        if [[ $createDate -lt $olderThan ]]; then
-            fileName=$(echo $line | awk {'print $4'})
-            if [[ $fileName != "" ]]; then
+        if [ $createDate -lt $olderThan ]; then
+            fileName=$(echo "$line" | awk '{print $4}')
+            if [ $fileName != "" ]; then
                 s3cmd del "${S3_URI}/$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
             fi
         fi

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -17,7 +17,7 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
-        olderThan=$(date --date @$(($(date +%s) - 86400*$S3_EXPIRE_DAYS)) +%s)
+        olderThan=$(date --date @$(($(date +%s) - 86400*S3_EXPIRE_DAYS)) +%s)
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -17,11 +17,11 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
-        olderThan=$(date --date @$(($(date +%s$) - 86400*$S3_EXPIRE_DAYS)) +%s)
+        olderThan=$(date --date @$(($(date +%s) - 86400*$S3_EXPIRE_DAYS)) +%s)
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then
-                s3cmd del "${S3_URI}/$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
+                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
             fi
         fi
     done;


### PR DESCRIPTION
In AWS S3 you can use [lifecycle rules to remove expired objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html).

However, I was wondering how this works in other S3 compatible storage servers, where the lifecycle rules are not implemented, such as Exoscale (see [limitations](https://community.exoscale.com/documentation/storage/simple-object-storage-overview/#s3-unsupported-features)) or cloudscale?

I think there needs to be some process that regularly iterates all the objects and decides which ones to prune, no?

Let's discuss..