### PR TITLE
Fix(kubernetes): make jwt auth role configurable

### DIFF
--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -8,7 +8,7 @@ JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 export JWT
 if [ "${USE_JWT_AUTH}" = "true" ]; then
     echo "Using JWT Auth"
-    VAULT_TOKEN=$(vault write -field=token auth/jwt/login role=my-role jwt="$JWT")
+    VAULT_TOKEN=$(vault write -field=token auth/jwt/login role="${VAULT_ROLE}" jwt="$JWT")
     export VAULT_TOKEN
 else
     echo "Using Kubernetes Auth"


### PR DESCRIPTION
- Currently, the role is hardcoded to my-role, which is a mistake
- It will be configurable by the VAULT_ROLE env var, like with Kubernetes auth.