### PR TITLE
Feat/make auth path configurable

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -12,7 +12,7 @@ After the snapshot is created in a temporary directory, `s3cmd` is used to sync 
 
 * `VAULT_ADDR`  - Vault address to access
 * `VAULT_ROLE` - Vault role to use to create the snapshot
-* `USE_JWT_AUTH` - If set to true; the script will use JWT authentication else it will use kubernetes authentication
+* `VAULT_AUTH_PATH` - The path of the Kubernetes authentication backend in Vault (e.g. `kubernetes`)
 * `S3_URI` - S3 URI to use to upload (s3://xxx)
 * `S3_BUCKET` - S3 bucket to point to
 * `S3_HOST` - S3 endpoint

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -2,26 +2,26 @@
 
 set -e
 
+# Set default Vault auth path if not provided
+VAULT_AUTH_PATH=${VAULT_AUTH_PATH:-auth/kubernetes/login}
+
+echo "Using Vault auth path: $VAULT_AUTH_PATH"
 
 # Authenticate with Vault
 JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 export JWT
-if [ "${USE_JWT_AUTH}" = "true" ]; then
-    echo "Using JWT Auth"
-    VAULT_TOKEN=$(vault write -field=token auth/jwt/login role="${VAULT_ROLE}" jwt="$JWT")
-    export VAULT_TOKEN
-else
-    echo "Using Kubernetes Auth"
-    VAULT_TOKEN=$(vault write -field=token auth/kubernetes/login role="${VAULT_ROLE}" jwt="${JWT}")
-    export VAULT_TOKEN
-fi
-# create snapshot
+
+echo "Using Vault auth path: $VAULT_AUTH_PATH"
+VAULT_TOKEN=$(vault write -field=token "$VAULT_AUTH_PATH" role="${VAULT_ROLE}" jwt="$JWT")
+export VAULT_TOKEN
+
+# Create snapshot
 vault operator raft snapshot save /vault-snapshots/vault_"$(date +%F-%H%M)".snapshot
 
-# upload to s3
+# Upload to S3
 s3cmd put /vault-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
 
-# remove expired snapshots
+# Remove expired snapshots
 if [ "${S3_EXPIRE_DAYS}" ]; then
     s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
@@ -33,5 +33,5 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
                 s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
             fi
         fi
-    done;
+    done
 fi

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -33,5 +33,5 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
                 s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
             fi
         fi
-    done
+    done;
 fi

--- a/kubernetes/vault-snapshot.sh
+++ b/kubernetes/vault-snapshot.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Set default Vault auth path if not provided
-VAULT_AUTH_PATH=${VAULT_AUTH_PATH:-auth/kubernetes/login}
+VAULT_AUTH_PATH=${VAULT_AUTH_PATH:-kubernetes}
 
 echo "Using Vault auth path: $VAULT_AUTH_PATH"
 
@@ -12,7 +12,7 @@ JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 export JWT
 
 echo "Using Vault auth path: $VAULT_AUTH_PATH"
-VAULT_TOKEN=$(vault write -field=token "$VAULT_AUTH_PATH" role="${VAULT_ROLE}" jwt="$JWT")
+VAULT_TOKEN=$(vault write -field=token "auth/$VAULT_AUTH_PATH/login" role="${VAULT_ROLE}" jwt="$JWT")
 export VAULT_TOKEN
 
 # Create snapshot


### PR DESCRIPTION
Currently, the path of the authentication backend must be either Kubernetes or JWT.
With this pr it should be freely configurable.